### PR TITLE
Add --debug-dash commandline flag.

### DIFF
--- a/OpenEIT/dashboard/dash_control.py
+++ b/OpenEIT/dashboard/dash_control.py
@@ -23,9 +23,10 @@ logger = logging.getLogger(__name__)
 
 class runGui(object):
 
-    def __init__(self,controller):
+    def __init__(self, controller, debug=False):
 
         # Both controller and app have to be passed to the dynamically loaded page to enable callbacks and functionality with the rest of the package. 
+        self.debug = debug
         self.controller = controller
         self.app = None
 
@@ -210,7 +211,7 @@ class runGui(object):
                     return csv_string  
   
         # Switch to False    
-        self.app.run_server(debug=False)
+        self.app.run_server(debug=self.debug)
 
     def on_connection_state_changed(self, connected):
         if connected:

--- a/app.py
+++ b/app.py
@@ -53,6 +53,10 @@ def main():
     ap.add_argument("--virtual-tty",
                     action="store_true",
                     default=False)
+    ap.add_argument("--debug-dash",
+                    action="store_true",
+                    default=False,
+                    help="Show debug messages in GUI.")
     ap.add_argument("port", nargs="?")
 
     args = ap.parse_args()
@@ -68,7 +72,7 @@ def main():
         #mode=mode
     )
 
-    gui = runGui(controller)
+    gui = runGui(controller, args.debug_dash)
     gui.run()
 
 


### PR DESCRIPTION
Now you can run with 

```
python ./app.py --debug-dash
```

Another way to do this would be to have a debug flag that takes an argument like `--debug=dash,server,etc`, so that we can choose a set of debug types, but I think simpler is better for now.

If you like this I'll add a commit to this PR to update the README.