### PR TITLE
Compatibility with plotly v4

### DIFF
--- a/OpenEIT/dashboard/modes/fw.py
+++ b/OpenEIT/dashboard/modes/fw.py
@@ -10,7 +10,7 @@ import dash
 from dash.dependencies import Output,Input,State
 import dash_core_components as dcc
 import dash_html_components as html
-import plotly.plotly as py
+import chart_studio.plotly as py
 import plotly.graph_objs as go
 from flask import send_from_directory
 import serial.tools.list_ports

--- a/OpenEIT/dashboard/modes/imaging.py
+++ b/OpenEIT/dashboard/modes/imaging.py
@@ -10,7 +10,7 @@ import dash
 from dash.dependencies import Input, Output, State
 import dash_core_components as dcc
 import dash_html_components as html
-import plotly.plotly as py
+import chart_studio.plotly as py
 from plotly.graph_objs import *
 import plotly.graph_objs as go
 import plotly.figure_factory as FF

--- a/OpenEIT/dashboard/modes/spectroscopy.py
+++ b/OpenEIT/dashboard/modes/spectroscopy.py
@@ -10,7 +10,7 @@ import dash
 from dash.dependencies import Output, Input
 import dash_core_components as dcc
 import dash_html_components as html
-import plotly.plotly as py
+import chart_studio.plotly as py
 import plotly.graph_objs as go
 from flask import send_from_directory
 import serial.tools.list_ports

--- a/OpenEIT/dashboard/modes/time_series.py
+++ b/OpenEIT/dashboard/modes/time_series.py
@@ -10,7 +10,7 @@ import dash
 from dash.dependencies import Output, Input
 import dash_core_components as dcc
 import dash_html_components as html
-import plotly.plotly as py
+import chart_studio.plotly as py
 import plotly.graph_objs as go
 from flask import send_from_directory
 import serial.tools.list_ports


### PR DESCRIPTION
The `plotly.plotly` imports are no longer compatible to plotly version 4. See https://plotly.com/python/v4-migration/.